### PR TITLE
Move the sketch.proto from the CMMS-api repo to anysketch.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -89,13 +89,3 @@ cc_library(
     remote = "https://github.com/google/farmhash.git",
     shallow_since = "1509400690 -0700",
 )
-
-# Measurement APIs.
-http_archive(
-    name = "wfa_measurement_proto",
-    sha256 = "5552203aa815659eace1cb96c84c45ef1290ab87bba7e424311ae629b159b212",
-    strip_prefix = "cross-media-measurement-api-1303ecbf4e81901f30f5a400b80921871b701b37",
-    urls = [
-        "https://github.com/world-federation-of-advertisers/cross-media-measurement-api/archive/1303ecbf4e81901f30f5a400b80921871b701b37.tar.gz",
-    ],
-)

--- a/src/main/cc/any_sketch/crypto/BUILD.bazel
+++ b/src/main/cc/any_sketch/crypto/BUILD.bazel
@@ -10,13 +10,13 @@ cc_library(
         "//src/main/cc/any_sketch/util:macros",
         "//src/main/cc/math:distributions",
         "//src/main/cc/math:noise_parameters_computation",
+        "//src/main/proto/wfa/any_sketch:sketch_cc_proto",
         "//src/main/proto/wfa/any_sketch/crypto:sketch_encryption_methods_cc_proto",
         "//src/main/proto/wfa/common:el_gamal_key_cc_proto",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/types:span",
         "@com_google_private_join_and_compute//crypto:commutative_elgamal",
         "@com_google_private_join_and_compute//util:status_includes",
-        "@wfa_measurement_proto//src/main/proto/wfa/measurement/api/v1alpha:sketch_cc_proto",
     ],
 )
 

--- a/src/main/cc/any_sketch/crypto/sketch_encrypter.cc
+++ b/src/main/cc/any_sketch/crypto/sketch_encrypter.cc
@@ -38,11 +38,11 @@ using ::private_join_and_compute::CommutativeElGamal;
 using ::private_join_and_compute::Context;
 using ::private_join_and_compute::ECGroup;
 using ::private_join_and_compute::ECPoint;
+using ::wfa::any_sketch::Sketch;
+using ::wfa::any_sketch::SketchConfig;
 using ::wfa::common::DifferentialPrivacyParams;
 using ::wfa::math::GetPublisherNoiseOptions;
 using ::wfa::math::GetTruncatedDiscreteLaplaceDistributedRandomNumber;
-using ::wfa::measurement::api::v1alpha::Sketch;
-using ::wfa::measurement::api::v1alpha::SketchConfig;
 using DestroyedRegisterStrategy =
     ::wfa::any_sketch::crypto::EncryptSketchRequest::DestroyedRegisterStrategy;
 using BlindersCiphertext = std::pair<std::string, std::string>;

--- a/src/main/cc/any_sketch/crypto/sketch_encrypter.h
+++ b/src/main/cc/any_sketch/crypto/sketch_encrypter.h
@@ -21,8 +21,8 @@
 
 #include "absl/status/statusor.h"
 #include "wfa/any_sketch/crypto/sketch_encryption_methods.pb.h"
+#include "wfa/any_sketch/sketch.pb.h"
 #include "wfa/common/el_gamal_key.pb.h"
-#include "wfa/measurement/api/v1alpha/sketch.pb.h"
 
 namespace wfa::any_sketch::crypto {
 
@@ -46,7 +46,7 @@ class SketchEncrypter {
   // Return the word by word ElGamal encryption of the sketch. The result is
   // the concatenation of all ciphertext strings.
   virtual absl::StatusOr<std::string> Encrypt(
-      const wfa::measurement::api::v1alpha::Sketch& sketch,
+      const wfa::any_sketch::Sketch& sketch,
       EncryptSketchRequest::DestroyedRegisterStrategy
           destroyed_register_strategy) = 0;
 

--- a/src/main/proto/wfa/any_sketch/BUILD.bazel
+++ b/src/main/proto/wfa/any_sketch/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_cc//cc:defs.bzl", "cc_proto_library")
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+package(default_visibility = ["//visibility:public"])
+
+IMPORT_PREFIX = "/src/main/proto"
+
+proto_library(
+    name = "sketch_proto",
+    srcs = ["sketch.proto"],
+    strip_import_prefix = IMPORT_PREFIX,
+)
+
+cc_proto_library(
+    name = "sketch_cc_proto",
+    deps = [":sketch_proto"],
+)

--- a/src/main/proto/wfa/any_sketch/crypto/BUILD.bazel
+++ b/src/main/proto/wfa/any_sketch/crypto/BUILD.bazel
@@ -8,8 +8,8 @@ proto_library(
     srcs = ["sketch_encryption_methods.proto"],
     strip_import_prefix = "/src/main/proto",
     deps = [
+        "//src/main/proto/wfa/any_sketch:sketch_proto",
         "//src/main/proto/wfa/common:el_gamal_key_proto",
-        "@wfa_measurement_proto//src/main/proto/wfa/measurement/api/v1alpha:sketch_proto",
     ],
 )
 

--- a/src/main/proto/wfa/any_sketch/crypto/sketch_encryption_methods.proto
+++ b/src/main/proto/wfa/any_sketch/crypto/sketch_encryption_methods.proto
@@ -16,8 +16,8 @@ syntax = "proto3";
 
 package wfa.any_sketch.crypto;
 
+import "wfa/any_sketch/sketch.proto";
 import "wfa/common/el_gamal_key.proto";
-import "wfa/measurement/api/v1alpha/sketch.proto";
 
 option java_package = "org.wfanet.anysketch.crypto";
 option java_multiple_files = true;
@@ -25,7 +25,7 @@ option java_multiple_files = true;
 // The request to encrypt a sketch.
 message EncryptSketchRequest {
   // The input sketch
-  wfa.measurement.api.v1alpha.Sketch sketch = 1;
+  wfa.any_sketch.Sketch sketch = 1;
   // Public keys of the ElGamal cipher used to encrypt the sketch
   wfa.common.ElGamalPublicKey el_gamal_keys = 2;
   // The elliptical curve to work on.

--- a/src/main/proto/wfa/any_sketch/sketch.proto
+++ b/src/main/proto/wfa/any_sketch/sketch.proto
@@ -1,0 +1,191 @@
+// Copyright 2020 The Cross-Media Measurement Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Protobuffer for the generalized enriched cardinality sketch.
+// SketchConfig is configuration of the sketch.
+// Sketch is the sketch itself.
+
+syntax = "proto3";
+
+package wfa.any_sketch;
+
+option java_package = "org.wfanet.anysketch";
+option java_multiple_files = true;
+option java_outer_classname = "SketchProto";
+
+// Truncated discretized exponential distrbution.
+// https://en.wikipedia.org/wiki/Exponential_distribution
+message ExponentialDistribution {
+  // Probability of i-th element is proportional to
+  // exp(-rate / max_value * i).
+  double rate = 1;
+  int64 num_values = 2;
+}
+
+// Integer geometric distribution truncated to 0, ..., num_values - 1.
+// https://en.wikipedia.org/wiki/Geometric_distribution
+message GeometricDistribution {
+  // Probability of i-th element is equal to
+  // (1 - success_probability) ^ k.
+  // Except for the last element, which gets the remaining probability.
+  double success_probability = 1;
+  int64 num_values = 2;
+}
+
+// Integer uniform distribution from 0 to num_values - 1.
+// Mathematically it is an exponential distribution with rate 0.
+// Providing a direct way to specify it for convenience.
+// https://en.wikipedia.org/wiki/Discrete_uniform_distribution
+message UniformDistribution {
+  // Max value. Full int64 random if unspecified.
+  int64 num_values = 1;
+}
+
+// Degenerate constant distribution.
+// https://en.wikipedia.org/wiki/Degenerate_distribution
+message ConstantDistribution {
+  // Value of the constant distribution.
+  int64 value = 1;
+}
+
+// Dirac Mixture distribution.
+// TODO(evgenys): Add .md documentation.
+// See https://research.google/pubs/pub48387/
+message DiracMixtureDistribution {
+  // DiracDelta corresponds to a pool of num_values * alpha indexes.
+  // Probability of allocation into the pool is equal to alpha * activity.
+  // Probability within the pool is uniform.
+  // DiracDeltas as allocated on the integer line sequentially.
+  // I.e. the first  one uses index values from 0 to num_values * alpha_1 - 1,
+  // the second from num_values * alpha_1 to
+  // num_values * (alpha_1 + alpha_2) - 1 etc.
+  message DiracDelta {
+    double alpha = 1;
+    double activity = 2;
+  }
+  repeated DiracDelta deltas = 1;
+  int64 num_values = 2;
+}
+
+// Brute-force specification of a discrete probability distribution.
+// Probability of index equal to i is equal to index_probability[i].
+message VerbatimDistribution {
+  repeated double index_probability = 1;
+}
+
+// Represents a value coming from the user. E.g. frequency, demo.
+// TODO(evgenys): Add link to public design doc for oracle distribution.
+message OracleDistribution {
+  // Key used to extract the value from context.
+  string key = 1;
+}
+
+// Random distribution.
+message Distribution {
+  oneof distribution_choice {
+    ExponentialDistribution exponential = 1;
+    UniformDistribution uniform = 2;
+    GeometricDistribution geometric = 3;
+    ConstantDistribution constant = 4;
+    DiracMixtureDistribution dirac_mixture = 5;
+    VerbatimDistribution verbatim = 6;
+    OracleDistribution oracle = 15;
+  }
+}
+
+// Enriched cardinality sketch config.
+message SketchConfig {
+  message Key {
+    string sketch_config_id = 1;
+  }
+  // The sketch may be GENERIC or using a specific optimized implementation.
+  enum SketchType { GENERIC = 0; }
+  // Index specification.
+  // Indexes are unsigned integers.
+  message IndexSpec {
+    // Name of the index. Truly optional.
+    string name = 1;
+    // Distribution of the index.
+    Distribution distribution = 2;
+  }
+
+  // Value specification.
+  // Values are unsigned integers.
+  message ValueSpec {
+    // Aggregation function specification.
+    // Any function here should be computable homomorphically.
+    enum Aggregator {
+      // This should never be encountered.
+      AGGREGATOR_UNSPECIFIED = 0;
+      // Sums the values.
+      SUM = 1;
+      // Stores a value if only that value is seen.
+      // If more than one distinct value occurred then result is -1.
+      // Negative values are never valid values.
+      // Only values less than 2^32 are valid for UNIQUE aggregator, as
+      // In the encrypted protocol this corresponds to random value stored
+      // if more than one value occurred. Negatives and values above 2^32 are
+      // replaced with -1.
+      // Probability of a random value treated as valid is 2^-32 ~ 1/1B.
+      // TODO(evgenys): Move design to .md file.
+      // See Section 6.1 in https://research.google/pubs/pub49177/
+      UNIQUE = 2;
+    }
+    // Name of the value.
+    string name = 1;
+    // Distribution of the value. It is often constant or oracle.
+    Distribution distribution = 2;
+    // How to aggregate the value.
+    Aggregator aggregator = 3;
+  }
+  // Resource key.
+  Key key = 1;
+  // Type of the sketch. You can always use GENERIC if highly tuned performance
+  // is not required.
+  SketchType sketch_type = 2;
+  // NOTE: In configs singular fields look better, but as we are going to
+  // opensource the code we should probably follow the guidelines on
+  // plural names for repeated fields.
+  // How to generate each index?
+  repeated IndexSpec indexes = 3;
+  // How to generate each value?
+  repeated ValueSpec values = 4;
+
+  // See b/152452184 for how to extend the sketch to reservoir sampling when
+  // running in the clear.
+}
+
+// Generalized enriched cardinality sketch.
+// To add an item to the sketch:
+// Convert an item to a register.
+// Try to find register with the same index.
+// If found:
+//   aggregate the values in the sketch register with the sketch of the item
+// otherwise:
+//   insert a new register.
+// Sketch is inherently sparse, as this allows usage of UNIQUE
+// aggregation in SMPC.
+message Sketch {
+  // Enriched cardinality sketch register.
+  message Register {
+    // Linearized register index. E.g. LiquidLegion bucket.
+    int64 index = 1;
+    // Values of the register. E.g. LiquidLegion frequency.
+    repeated int64 values = 2;
+  }
+  // Config can be provided explicitly, or determined from context.
+  SketchConfig config = 1;
+  // Registers of the sketch.
+  repeated Register registers = 2;
+}

--- a/src/main/proto/wfa/any_sketch/sketch.proto
+++ b/src/main/proto/wfa/any_sketch/sketch.proto
@@ -106,9 +106,6 @@ message Distribution {
 
 // Enriched cardinality sketch config.
 message SketchConfig {
-  message Key {
-    string sketch_config_id = 1;
-  }
   // The sketch may be GENERIC or using a specific optimized implementation.
   enum SketchType { GENERIC = 0; }
   // Index specification.
@@ -149,18 +146,16 @@ message SketchConfig {
     // How to aggregate the value.
     Aggregator aggregator = 3;
   }
-  // Resource key.
-  Key key = 1;
   // Type of the sketch. You can always use GENERIC if highly tuned performance
   // is not required.
-  SketchType sketch_type = 2;
+  SketchType sketch_type = 1;
   // NOTE: In configs singular fields look better, but as we are going to
   // opensource the code we should probably follow the guidelines on
   // plural names for repeated fields.
   // How to generate each index?
-  repeated IndexSpec indexes = 3;
+  repeated IndexSpec indexes = 2;
   // How to generate each value?
-  repeated ValueSpec values = 4;
+  repeated ValueSpec values = 3;
 
   // See b/152452184 for how to extend the sketch to reservoir sampling when
   // running in the clear.

--- a/src/test/cc/any_sketch/crypto/BUILD.bazel
+++ b/src/test/cc/any_sketch/crypto/BUILD.bazel
@@ -23,9 +23,9 @@ cc_test(
     ],
     deps = [
         "//src/main/cc/any_sketch/crypto:sketch_encrypter_adapter",
+        "//src/main/proto/wfa/any_sketch:sketch_cc_proto",
         "//src/test/cc/testutil:random",
         "//src/test/cc/testutil:status_macros",
         "@googletest//:gtest_main",
-        "@wfa_measurement_proto//src/main/proto/wfa/measurement/api/v1alpha:sketch_cc_proto",
     ],
 )

--- a/src/test/cc/any_sketch/crypto/sketch_encrypter_adapter_test.cc
+++ b/src/test/cc/any_sketch/crypto/sketch_encrypter_adapter_test.cc
@@ -32,8 +32,8 @@ using ::private_join_and_compute::ECGroup;
 using ::private_join_and_compute::ECPoint;
 using ::private_join_and_compute::InternalError;
 using ::testing::SizeIs;
-using ::wfa::measurement::api::v1alpha::Sketch;
-using ::wfa::measurement::api::v1alpha::SketchConfig;
+using ::wfa::any_sketch::Sketch;
+using ::wfa::any_sketch::SketchConfig;
 
 constexpr int kTestCurveId = NID_X9_62_prime256v1;
 constexpr int kMaxCounterValue = 100;

--- a/src/test/cc/any_sketch/crypto/sketch_encrypter_test.cc
+++ b/src/test/cc/any_sketch/crypto/sketch_encrypter_test.cc
@@ -37,9 +37,9 @@ using ::private_join_and_compute::ECGroup;
 using ::private_join_and_compute::ECPoint;
 using ::testing::Not;
 using ::testing::SizeIs;
+using ::wfa::any_sketch::Sketch;
+using ::wfa::any_sketch::SketchConfig;
 using ::wfa::common::ElGamalPublicKey;
-using ::wfa::measurement::api::v1alpha::Sketch;
-using ::wfa::measurement::api::v1alpha::SketchConfig;
 
 constexpr int kTestCurveId = NID_X9_62_prime256v1;
 constexpr int kMaxCounterValue = 100;


### PR DESCRIPTION
This file is copied from
https://github.com/world-federation-of-advertisers/cross-media-measurement-api/blob/c257ae4f0790d5080875edf80f536c4ae422ee19/src/main/proto/wfa/measurement/api/v2alpha/sketch.proto

The sketchConfig is acutally an anysketch concept. In CMMS, we use
protocol specific config + bytes to denote a sketch. Moving the
sketchproto into anysketch makes the ansketch repo a leaf repo.

The EncryptedSketch.proto and Sketch.proto inside CMMS-api would be
deleted.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/any-sketch/5)
<!-- Reviewable:end -->
