### PR TITLE
Add unit test for sketches with empty values.

### DIFF
--- a/src/test/cc/any_sketch/any_sketch_test.cc
+++ b/src/test/cc/any_sketch/any_sketch_test.cc
@@ -152,6 +152,14 @@ TEST(AnySketchTest, MultipleOracleDistributions) {
               UnorderedElementsAre(RegisterIs(4, {10, 11})));
 }
 
+TEST(AnySketchTest, EmptyValues) {
+  std::vector<ValueFunction> value_functions;
+  AnySketch sketch(MakeFakeDistributionIndex(), std::move(value_functions));
+
+  ASSERT_THAT(sketch.Insert("ABCD", {}), IsOk());
+  EXPECT_THAT(GetRegisters(sketch), UnorderedElementsAre(RegisterIs(4, {})));
+}
+
 TEST(AnySketchTest, FakeDistribution) {
   AnySketch sketch(MakeFakeDistributionIndex(),
                    MakeSingleItemVector(MakeValueFunction(

--- a/src/test/cc/any_sketch/any_sketch_test.cc
+++ b/src/test/cc/any_sketch/any_sketch_test.cc
@@ -153,8 +153,7 @@ TEST(AnySketchTest, MultipleOracleDistributions) {
 }
 
 TEST(AnySketchTest, EmptyValues) {
-  std::vector<ValueFunction> value_functions;
-  AnySketch sketch(MakeFakeDistributionIndex(), std::move(value_functions));
+  AnySketch sketch(MakeFakeDistributionIndex(), std::vector<ValueFunction>());
 
   ASSERT_THAT(sketch.Insert("ABCD", {}), IsOk());
   EXPECT_THAT(GetRegisters(sketch), UnorderedElementsAre(RegisterIs(4, {})));

--- a/src/test/cc/any_sketch/crypto/sketch_encrypter_test.cc
+++ b/src/test/cc/any_sketch/crypto/sketch_encrypter_test.cc
@@ -210,6 +210,21 @@ TEST_F(SketchEncrypterTest, ByteSizeShouldBeCorrect) {
   EXPECT_EQ(result.size(), register_size * (1 + unique_cnt + sum_cnt) * 66);
 }
 
+TEST_F(SketchEncrypterTest, EncryptionOfEmptyValuesShouldBeComplete) {
+  const int register_size = 1000;
+
+  Sketch plain_sketch;
+  *plain_sketch.mutable_config() =
+      CreateSketchConfig(/* unique_cnt = */ 0, /* sum_cnt = */ 0);
+  for (size_t i = 0; i < register_size; i++) {
+    plain_sketch.add_registers()->set_index(RandomInt64());
+  }
+
+  ASSERT_OK_AND_ASSIGN(std::string result,
+                       EncryptWithConflictingKeys(plain_sketch));
+  EXPECT_EQ(result.size(), register_size * 1 * 66);
+}
+
 TEST_F(SketchEncrypterTest, EncryptionShouldBeNonDeterministic) {
   Sketch plain_sketch;
   *plain_sketch.mutable_config() =

--- a/src/test/cc/any_sketch/crypto/sketch_encrypter_test.cc
+++ b/src/test/cc/any_sketch/crypto/sketch_encrypter_test.cc
@@ -211,18 +211,19 @@ TEST_F(SketchEncrypterTest, ByteSizeShouldBeCorrect) {
 }
 
 TEST_F(SketchEncrypterTest, EncryptionOfEmptyValuesShouldBeComplete) {
-  const int register_size = 1000;
+  const int register_count = 1000;
 
   Sketch plain_sketch;
+  // Sketch config specifies no values in registers.
   *plain_sketch.mutable_config() =
       CreateSketchConfig(/* unique_cnt = */ 0, /* sum_cnt = */ 0);
-  for (size_t i = 0; i < register_size; i++) {
+  for (size_t i = 0; i < register_count; i++) {
     plain_sketch.add_registers()->set_index(RandomInt64());
   }
 
   ASSERT_OK_AND_ASSIGN(std::string result,
                        EncryptWithConflictingKeys(plain_sketch));
-  EXPECT_EQ(result.size(), register_size * 1 * 66);
+  EXPECT_EQ(result.size(), register_count * 1 * 66);
 }
 
 TEST_F(SketchEncrypterTest, EncryptionShouldBeNonDeterministic) {


### PR DESCRIPTION
With new MPC protocol Reach-Only LLV2, registers in sketches only have index without any values. The test units are added to verify that sketches without values are able to be created and encrypted successfully.