### PR TITLE
Verify the OpenSSL implementation of the AES counter mode against NIST's test vector.

### DIFF
--- a/src/main/cc/math/open_ssl_uniform_random_generator.h
+++ b/src/main/cc/math/open_ssl_uniform_random_generator.h
@@ -62,6 +62,15 @@ class OpenSslUniformRandomGenerator {
   int status();
 };
 
+// A uniform pseudorandom generator based on AES-256 counter mode. This is one
+// of the approved Deterministic Random Bit Generators specified in the NIST
+// SP 800-90A Rev.1 documentation.
+//
+// The AES is initialized with a key and an IV. The IV is used as the initial
+// counter and has the same length as the block length.
+//
+// Any implementation of the AES-256 counter mode must be verified against the
+// test vectors specified in the NIST SP 800-38A documentation.
 class OpenSslUniformPseudorandomGenerator
     : public UniformPseudorandomGenerator {
  public:

--- a/src/test/cc/math/open_ssl_uniform_random_generator_test.cc
+++ b/src/test/cc/math/open_ssl_uniform_random_generator_test.cc
@@ -201,5 +201,51 @@ TEST(OpenSslUniformPseudorandomGenerator,
   ASSERT_EQ(seq1, seq2);
 }
 
+TEST(OpenSslUniformPseudorandomGenerator,
+     OpenSslPRNGCompliceWithNISTTestVectorSucceeds) {
+  std::vector<unsigned char> key = {
+      0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe, 0x2b, 0x73, 0xae,
+      0xf0, 0x85, 0x7d, 0x77, 0x81, 0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61,
+      0x08, 0xd7, 0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14, 0xdf, 0xf4};
+  std::vector<unsigned char> iv = {0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5,
+                                   0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb,
+                                   0xfc, 0xfd, 0xfe, 0xff};
+  std::vector<unsigned char> output_block_1 = {
+      0x0b, 0xdf, 0x7d, 0xf1, 0x59, 0x17, 0x16, 0x33,
+      0x5e, 0x9a, 0x8b, 0x15, 0xc8, 0x60, 0xc5, 0x02};
+  std::vector<unsigned char> output_block_2 = {
+      0x5a, 0x6e, 0x69, 0x9d, 0x53, 0x61, 0x19, 0x06,
+      0x54, 0x33, 0x86, 0x3c, 0x8f, 0x65, 0x7b, 0x94};
+  std::vector<unsigned char> output_block_3 = {
+      0x1b, 0xc1, 0x2c, 0x9c, 0x01, 0x61, 0x0d, 0x5d,
+      0x0d, 0x8b, 0xd6, 0xa3, 0x37, 0x8e, 0xca, 0x62};
+  std::vector<unsigned char> output_block_4 = {
+      0x29, 0x56, 0xe1, 0xc8, 0x69, 0x35, 0x36, 0xb1,
+      0xbe, 0xe9, 0x9c, 0x73, 0xa3, 0x15, 0x76, 0xb6};
+
+  ASSERT_OK_AND_ASSIGN(std::unique_ptr<UniformPseudorandomGenerator> prng,
+                       OpenSslUniformPseudorandomGenerator::Create(key, iv));
+
+  int kNumRandomBytes = 16;
+  ASSERT_OK_AND_ASSIGN(std::vector<unsigned char> seq1,
+                       prng->GetPseudorandomBytes(kNumRandomBytes));
+  ASSERT_OK_AND_ASSIGN(std::vector<unsigned char> seq2,
+                       prng->GetPseudorandomBytes(kNumRandomBytes));
+  ASSERT_OK_AND_ASSIGN(std::vector<unsigned char> seq3,
+                       prng->GetPseudorandomBytes(kNumRandomBytes));
+  ASSERT_OK_AND_ASSIGN(std::vector<unsigned char> seq4,
+                       prng->GetPseudorandomBytes(kNumRandomBytes));
+
+  ASSERT_EQ(seq1.size(), kNumRandomBytes);
+  ASSERT_EQ(seq2.size(), kNumRandomBytes);
+  ASSERT_EQ(seq3.size(), kNumRandomBytes);
+  ASSERT_EQ(seq4.size(), kNumRandomBytes);
+
+  ASSERT_EQ(seq1, output_block_1);
+  ASSERT_EQ(seq2, output_block_2);
+  ASSERT_EQ(seq3, output_block_3);
+  ASSERT_EQ(seq4, output_block_4);
+}
+
 }  // namespace
 }  // namespace wfa::math

--- a/src/test/cc/math/open_ssl_uniform_random_generator_test.cc
+++ b/src/test/cc/math/open_ssl_uniform_random_generator_test.cc
@@ -203,48 +203,51 @@ TEST(OpenSslUniformPseudorandomGenerator,
 
 TEST(OpenSslUniformPseudorandomGenerator,
      OpenSslPRNGCompliceWithNISTTestVectorSucceeds) {
-  std::vector<unsigned char> key = {
+  // The NIST's test vectors are defined at
+  // https://nvlpubs.nist.gov/nistpubs/legacy/sp/nistspecialpublication800-38a.pdf
+  std::vector<unsigned char> kTestKey = {
       0x60, 0x3d, 0xeb, 0x10, 0x15, 0xca, 0x71, 0xbe, 0x2b, 0x73, 0xae,
       0xf0, 0x85, 0x7d, 0x77, 0x81, 0x1f, 0x35, 0x2c, 0x07, 0x3b, 0x61,
       0x08, 0xd7, 0x2d, 0x98, 0x10, 0xa3, 0x09, 0x14, 0xdf, 0xf4};
-  std::vector<unsigned char> iv = {0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5,
-                                   0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb,
-                                   0xfc, 0xfd, 0xfe, 0xff};
-  std::vector<unsigned char> output_block_1 = {
+  std::vector<unsigned char> kTestIv = {0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5,
+                                        0xf6, 0xf7, 0xf8, 0xf9, 0xfa, 0xfb,
+                                        0xfc, 0xfd, 0xfe, 0xff};
+  std::vector<unsigned char> kOutputBlock1 = {
       0x0b, 0xdf, 0x7d, 0xf1, 0x59, 0x17, 0x16, 0x33,
       0x5e, 0x9a, 0x8b, 0x15, 0xc8, 0x60, 0xc5, 0x02};
-  std::vector<unsigned char> output_block_2 = {
+  std::vector<unsigned char> kOutputBlock2 = {
       0x5a, 0x6e, 0x69, 0x9d, 0x53, 0x61, 0x19, 0x06,
       0x54, 0x33, 0x86, 0x3c, 0x8f, 0x65, 0x7b, 0x94};
-  std::vector<unsigned char> output_block_3 = {
+  std::vector<unsigned char> kOutputBlock3 = {
       0x1b, 0xc1, 0x2c, 0x9c, 0x01, 0x61, 0x0d, 0x5d,
       0x0d, 0x8b, 0xd6, 0xa3, 0x37, 0x8e, 0xca, 0x62};
-  std::vector<unsigned char> output_block_4 = {
+  std::vector<unsigned char> kOutputBlock4 = {
       0x29, 0x56, 0xe1, 0xc8, 0x69, 0x35, 0x36, 0xb1,
       0xbe, 0xe9, 0x9c, 0x73, 0xa3, 0x15, 0x76, 0xb6};
 
-  ASSERT_OK_AND_ASSIGN(std::unique_ptr<UniformPseudorandomGenerator> prng,
-                       OpenSslUniformPseudorandomGenerator::Create(key, iv));
+  ASSERT_OK_AND_ASSIGN(
+      std::unique_ptr<UniformPseudorandomGenerator> prng,
+      OpenSslUniformPseudorandomGenerator::Create(kTestKey, kTestIv));
 
-  int kNumRandomBytes = 16;
+  int kBlockSize = 16;
   ASSERT_OK_AND_ASSIGN(std::vector<unsigned char> seq1,
-                       prng->GetPseudorandomBytes(kNumRandomBytes));
+                       prng->GetPseudorandomBytes(kBlockSize));
   ASSERT_OK_AND_ASSIGN(std::vector<unsigned char> seq2,
-                       prng->GetPseudorandomBytes(kNumRandomBytes));
+                       prng->GetPseudorandomBytes(kBlockSize));
   ASSERT_OK_AND_ASSIGN(std::vector<unsigned char> seq3,
-                       prng->GetPseudorandomBytes(kNumRandomBytes));
+                       prng->GetPseudorandomBytes(kBlockSize));
   ASSERT_OK_AND_ASSIGN(std::vector<unsigned char> seq4,
-                       prng->GetPseudorandomBytes(kNumRandomBytes));
+                       prng->GetPseudorandomBytes(kBlockSize));
 
-  ASSERT_EQ(seq1.size(), kNumRandomBytes);
-  ASSERT_EQ(seq2.size(), kNumRandomBytes);
-  ASSERT_EQ(seq3.size(), kNumRandomBytes);
-  ASSERT_EQ(seq4.size(), kNumRandomBytes);
+  ASSERT_EQ(seq1.size(), kBlockSize);
+  ASSERT_EQ(seq2.size(), kBlockSize);
+  ASSERT_EQ(seq3.size(), kBlockSize);
+  ASSERT_EQ(seq4.size(), kBlockSize);
 
-  ASSERT_EQ(seq1, output_block_1);
-  ASSERT_EQ(seq2, output_block_2);
-  ASSERT_EQ(seq3, output_block_3);
-  ASSERT_EQ(seq4, output_block_4);
+  ASSERT_EQ(seq1, kOutputBlock1);
+  ASSERT_EQ(seq2, kOutputBlock2);
+  ASSERT_EQ(seq3, kOutputBlock3);
+  ASSERT_EQ(seq4, kOutputBlock4);
 }
 
 }  // namespace


### PR DESCRIPTION
NIST provides test vectors for the AES-based block ciphers at the NIST SP 800-38A document (https://csrc.nist.gov/pubs/sp/800/38/a/final).