### PR TITLE
Add direct include needed for absl::StrCat

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -5,9 +5,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 # Common-cpp
 http_archive(
     name = "wfa_common_cpp",
-    sha256 = "dc0c388a8cc3ea36b189edd76efba50aebdc457b4662ed2fbca510a05cffb5ee",
-    strip_prefix = "common-cpp-0.10.2",
-    url = "https://github.com/world-federation-of-advertisers/common-cpp/archive/v0.10.2.tar.gz",
+    sha256 = "43398c7b44f692ef4a189afb674f27fa22e407797074a91d6db79908e6775162",
+    strip_prefix = "common-cpp-0.10.3",
+    url = "https://github.com/world-federation-of-advertisers/common-cpp/archive/v0.10.3.tar.gz",
 )
 
 load("@wfa_common_cpp//build:common_cpp_repositories.bzl", "common_cpp_repositories")

--- a/src/main/cc/any_sketch/any_sketch.cc
+++ b/src/main/cc/any_sketch/any_sketch.cc
@@ -25,6 +25,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "any_sketch/aggregators.h"

--- a/src/main/cc/any_sketch/crypto/sketch_encrypter.cc
+++ b/src/main/cc/any_sketch/crypto/sketch_encrypter.cc
@@ -19,6 +19,7 @@
 #include <utility>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/strings/str_cat.h"
 #include "common_cpp/macros/macros.h"
 #include "math/distributed_discrete_gaussian_noiser.h"
 #include "math/distributed_geometric_noiser.h"


### PR DESCRIPTION
Before this was used without a direct include statement, which relies on a transitive include to bring it into scope and can easily break... which it does with one of the more up-to-date versions of absl. This fix should help avoid breakages when we want to update the abseil dependency

Repro:
* Add the following to the WORKSPACE
```
git_repository(
  name = "com_google_absl",
  remote = "https://github.com/abseil/abseil-cpp",
  commit = "27478af36914f18867ea32cb42db00dba15fffcd",
)
```
* bazel build src/main/cc/any_sketch:any_sketch - errors out
  * After the fix, builds successfully