### PR TITLE
Use signed integer instead of unsigned integer for the PRNG's size argument.

### DIFF
--- a/src/main/cc/math/open_ssl_uniform_random_generator.cc
+++ b/src/main/cc/math/open_ssl_uniform_random_generator.cc
@@ -70,11 +70,16 @@ OpenSslUniformPseudorandomGenerator::Create(
 }
 
 absl::StatusOr<std::vector<unsigned char>>
-OpenSslUniformPseudorandomGenerator::GeneratePseudorandomBytes(uint64_t size) {
-  if (size == 0) {
+OpenSslUniformPseudorandomGenerator::GeneratePseudorandomBytes(int64_t size) {
+  if (size < 0) {
     return absl::InvalidArgumentError(
-        "Number of pseudorandom bytes must be a positive value.");
+        "Number of pseudorandom bytes must be a non-negative value.");
   }
+
+  if (size == 0) {
+    return std::vector<unsigned char>();
+  }
+
   std::vector<unsigned char> ret(size, 0);
   int length;
   if (EVP_EncryptUpdate(ctx_, ret.data(), &length, ret.data(), ret.size()) !=
@@ -92,14 +97,14 @@ OpenSslUniformPseudorandomGenerator::GeneratePseudorandomBytes(uint64_t size) {
 // sampling method.
 absl::StatusOr<std::vector<uint32_t>>
 OpenSslUniformPseudorandomGenerator::GenerateUniformRandomRange(
-    uint64_t size, uint32_t modulus) {
-  if (size == 0) {
-    return absl::InvalidArgumentError(
-        "Number of pseudorandom elements must be a positive value.");
-  }
-
+    int64_t size, uint32_t modulus) {
   if (modulus <= 1) {
     return absl::InvalidArgumentError("The modulus must be greater than 1.");
+  }
+
+  if (size < 0) {
+    return absl::InvalidArgumentError(
+        "Number of pseudorandom elements must be a non-negative value.");
   }
 
   // Compute the bit length of the modulus.
@@ -146,6 +151,7 @@ OpenSslUniformPseudorandomGenerator::GenerateUniformRandomRange(
       }
     }
   }
+
   return ret;
 }
 

--- a/src/main/cc/math/open_ssl_uniform_random_generator.h
+++ b/src/main/cc/math/open_ssl_uniform_random_generator.h
@@ -86,11 +86,11 @@ class OpenSslUniformPseudorandomGenerator
 
   // Generates a vector of pseudorandom bytes with the given size.
   absl::StatusOr<std::vector<unsigned char>> GeneratePseudorandomBytes(
-      uint64_t size) override;
+      int64_t size) override;
 
   // Generates a vector of `size` pseudorandom values in the range [0, modulus).
   absl::StatusOr<std::vector<uint32_t>> GenerateUniformRandomRange(
-      uint64_t size, uint32_t modulus) override;
+      int64_t size, uint32_t modulus) override;
 
  private:
   explicit OpenSslUniformPseudorandomGenerator(EVP_CIPHER_CTX* ctx)

--- a/src/main/cc/math/uniform_pseudorandom_generator.h
+++ b/src/main/cc/math/uniform_pseudorandom_generator.h
@@ -41,11 +41,11 @@ class UniformPseudorandomGenerator {
 
   // Generates a vector of pseudorandom bytes with the given size.
   virtual absl::StatusOr<std::vector<unsigned char>> GeneratePseudorandomBytes(
-      uint64_t size) = 0;
+      int64_t size) = 0;
 
   // Generates a vector of pseudorandom values in the range [0, modulus).
   virtual absl::StatusOr<std::vector<uint32_t>> GenerateUniformRandomRange(
-      uint64_t size, uint32_t modulus) = 0;
+      int64_t size, uint32_t modulus) = 0;
 
  protected:
   UniformPseudorandomGenerator() = default;

--- a/src/test/cc/math/open_ssl_uniform_random_generator_test.cc
+++ b/src/test/cc/math/open_ssl_uniform_random_generator_test.cc
@@ -23,7 +23,7 @@
 namespace wfa::math {
 namespace {
 
-using testing::IsEmpty;
+using ::testing::IsEmpty;
 
 TEST(OpenSslUniformPseudorandomGenerator,
      CreateTheGeneratorWithValidkeyAndIVSucceeds) {
@@ -78,10 +78,8 @@ TEST(OpenSslUniformPseudorandomGenerator,
   ASSERT_OK_AND_ASSIGN(std::unique_ptr<UniformPseudorandomGenerator> prng,
                        OpenSslUniformPseudorandomGenerator::Create(key, iv));
   auto seq = prng->GeneratePseudorandomBytes(-1);
-  EXPECT_THAT(
-      seq.status(),
-      StatusIs(absl::StatusCode::kInvalidArgument,
-               "Number of pseudorandom bytes must be a non-negative value."));
+  EXPECT_THAT(seq.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, "negative"));
 }
 
 TEST(OpenSslUniformPseudorandomGenerator,
@@ -277,11 +275,8 @@ TEST(OpenSslUniformPseudorandomGenerator,
   uint32_t kModulus = 128;
   uint64_t kNumRandomElements = -1;
   auto seq = prng->GenerateUniformRandomRange(kNumRandomElements, kModulus);
-  EXPECT_THAT(
-      seq.status(),
-      StatusIs(
-          absl::StatusCode::kInvalidArgument,
-          "Number of pseudorandom elements must be a non-negative value."));
+  EXPECT_THAT(seq.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, "negative"));
 }
 
 TEST(OpenSslUniformPseudorandomGenerator,
@@ -312,8 +307,8 @@ TEST(OpenSslUniformPseudorandomGenerator,
   uint32_t kModulus = 1;
   uint64_t kNumRandomElements = 1;
   auto seq = prng->GenerateUniformRandomRange(kNumRandomElements, kModulus);
-  EXPECT_THAT(seq.status(), StatusIs(absl::StatusCode::kInvalidArgument,
-                                     "The modulus must be greater than 1."));
+  EXPECT_THAT(seq.status(),
+              StatusIs(absl::StatusCode::kInvalidArgument, "modulus"));
 }
 
 TEST(OpenSslUniformPseudorandomGenerator,


### PR DESCRIPTION
The functions GeneratePseudorandomBytes and GenerateUniformRandomRange takes the argument `size` of type uint64_t. This will cause a problem if a negative number is provided. For example, -1 will be implicitly converted to 2^64-1, and GeneratePseudorandomBytes(-1) will become GeneratePseudorandomBytes(2^64-1).