### PR TITLE
Rename c++ ::wfa::any_sketch::Distribution to BaseDistribution to avoid colliding with proto.

### DIFF
--- a/src/main/cc/any_sketch/any_sketch.cc
+++ b/src/main/cc/any_sketch/any_sketch.cc
@@ -35,7 +35,7 @@
 
 namespace wfa::any_sketch {
 
-AnySketch::AnySketch(std::vector<std::unique_ptr<Distribution>> indexes,
+AnySketch::AnySketch(std::vector<std::unique_ptr<BaseDistribution>> indexes,
                      std::vector<ValueFunction> values)
     : indexes_(indexes.size()), values_(values.size()) {
   std::move(indexes.begin(), indexes.end(), indexes_.begin());
@@ -75,7 +75,7 @@ absl::StatusOr<int64_t> AnySketch::GetIndex(
     absl::string_view item, const ItemMetadata& item_metadata) const {
   uint64_t product = 1;
   uint64_t linearized_index = 0;
-  for (const std::unique_ptr<Distribution>& distribution : indexes_) {
+  for (const std::unique_ptr<BaseDistribution>& distribution : indexes_) {
     ASSIGN_OR_RETURN(int64_t distribution_value,
                      distribution->Apply(item, item_metadata));
     int64_t index_part = distribution_value - distribution->min_value();

--- a/src/main/cc/any_sketch/any_sketch.cc
+++ b/src/main/cc/any_sketch/any_sketch.cc
@@ -75,8 +75,7 @@ absl::StatusOr<int64_t> AnySketch::GetIndex(
     absl::string_view item, const ItemMetadata& item_metadata) const {
   uint64_t product = 1;
   uint64_t linearized_index = 0;
-  for (const std::unique_ptr<BaseDistribution>& distribution :
-       indexes_) {
+  for (const std::unique_ptr<BaseDistribution>& distribution : indexes_) {
     ASSIGN_OR_RETURN(int64_t distribution_value,
                      distribution->Apply(item, item_metadata));
     int64_t index_part = distribution_value - distribution->min_value();

--- a/src/main/cc/any_sketch/any_sketch.h
+++ b/src/main/cc/any_sketch/any_sketch.h
@@ -75,7 +75,7 @@ class AnySketch {
   // Creates a new, empty AnySketch.
   //
   // The inputs will be moved from.
-  AnySketch(std::vector<std::unique_ptr<Distribution>> indexes,
+  AnySketch(std::vector<std::unique_ptr<BaseDistribution>> indexes,
             std::vector<ValueFunction> values);
 
   AnySketch(const AnySketch &) = delete;
@@ -117,7 +117,7 @@ class AnySketch {
 
  private:
   absl::flat_hash_map<uint64_t, absl::FixedArray<ValueType>> registers_;
-  absl::FixedArray<std::unique_ptr<Distribution>> indexes_;
+  absl::FixedArray<std::unique_ptr<BaseDistribution>> indexes_;
   absl::FixedArray<ValueFunction> values_;
 
   size_t register_size() const;

--- a/src/main/cc/any_sketch/distributions.h
+++ b/src/main/cc/any_sketch/distributions.h
@@ -28,14 +28,14 @@ namespace wfa::any_sketch {
 
 using ItemMetadata = absl::flat_hash_map<std::string, int64_t>;
 
-// Base for representing distributions -- a way of deterministically mapping an
-// item and associated metadata to a number.
-class Distribution {
+// Abstract Base for representing distributions -- a way of deterministically
+// mapping an item and associated metadata to a number.
+class BaseDistribution {
  public:
-  Distribution(const Distribution&) = delete;
-  Distribution& operator=(const Distribution&) = delete;
+  BaseDistribution(const BaseDistribution&) = delete;
+  BaseDistribution& operator=(const BaseDistribution&) = delete;
 
-  virtual ~Distribution() = default;
+  virtual ~BaseDistribution() = default;
 
   // The smallest value (inclusive) that the Distribution can return.
   virtual int64_t min_value() const = 0;
@@ -52,16 +52,16 @@ class Distribution {
       absl::string_view item, const ItemMetadata& item_metadata) const = 0;
 
  protected:
-  Distribution() = default;
+  BaseDistribution() = default;
 };
 
-std::unique_ptr<Distribution> GetOracleDistribution(
+std::unique_ptr<BaseDistribution> GetOracleDistribution(
     absl::string_view feature_name, int64_t min_value, int64_t max_value);
-std::unique_ptr<Distribution> GetUniformDistribution(
+std::unique_ptr<BaseDistribution> GetUniformDistribution(
     const Fingerprinter* fingerprinter, int64_t min_value, int64_t max_value);
-std::unique_ptr<Distribution> GetExponentialDistribution(
+std::unique_ptr<BaseDistribution> GetExponentialDistribution(
     const Fingerprinter* fingerprinter, double rate, int64_t size);
-std::unique_ptr<Distribution> GetGeometricDistribution(
+std::unique_ptr<BaseDistribution> GetGeometricDistribution(
     const Fingerprinter* fingerprinter, int64_t min_value, int64_t max_value);
 
 }  // namespace wfa::any_sketch

--- a/src/main/cc/any_sketch/value_function.h
+++ b/src/main/cc/any_sketch/value_function.h
@@ -27,7 +27,7 @@ namespace wfa::any_sketch {
 struct ValueFunction {
   std::string name;
   AggregatorType aggregator_type;
-  std::unique_ptr<Distribution> distribution;
+  std::unique_ptr<BaseDistribution> distribution;
 };
 
 }  // namespace wfa::any_sketch

--- a/src/test/cc/any_sketch/any_sketch_test.cc
+++ b/src/test/cc/any_sketch/any_sketch_test.cc
@@ -97,9 +97,8 @@ std::vector<std::unique_ptr<BaseDistribution>> MakeFakeDistributionIndex() {
   return MakeSingleItemVector(MakeFakeDistribution());
 }
 
-ValueFunction MakeValueFunction(AggregatorType aggregator,
-                                std::unique_ptr<BaseDistribution>
-                                distribution) {
+ValueFunction MakeValueFunction(
+    AggregatorType aggregator, std::unique_ptr<BaseDistribution> distribution) {
   return {.name = "SomeValueFunction",
           .aggregator_type = aggregator,
           .distribution = std::move(distribution)};

--- a/src/test/cc/any_sketch/any_sketch_test.cc
+++ b/src/test/cc/any_sketch/any_sketch_test.cc
@@ -69,7 +69,7 @@ Matcher<AnySketch::Register> RegisterIs(uint64_t index,
       new RegisterIsMatcher(index, std::move(values)));
 }
 
-class FakeDistribution : public Distribution {
+class FakeDistribution : public BaseDistribution {
  public:
   absl::StatusOr<int64_t> Apply(
       absl::string_view item,
@@ -82,7 +82,7 @@ class FakeDistribution : public Distribution {
   int64_t max_value() const override { return 10; }
 };
 
-std::unique_ptr<Distribution> MakeFakeDistribution() {
+std::unique_ptr<BaseDistribution> MakeFakeDistribution() {
   return absl::make_unique<FakeDistribution>();
 }
 
@@ -93,12 +93,12 @@ std::vector<T> MakeSingleItemVector(T&& t) {
   return v;
 }
 
-std::vector<std::unique_ptr<Distribution>> MakeFakeDistributionIndex() {
+std::vector<std::unique_ptr<BaseDistribution>> MakeFakeDistributionIndex() {
   return MakeSingleItemVector(MakeFakeDistribution());
 }
 
-ValueFunction MakeValueFunction(AggregatorType aggregator,
-                                std::unique_ptr<Distribution> distribution) {
+ValueFunction MakeValueFunction(
+    AggregatorType aggregator, std::unique_ptr<BaseDistribution> distribution) {
   return {.name = "SomeValueFunction",
           .aggregator_type = aggregator,
           .distribution = std::move(distribution)};

--- a/src/test/cc/any_sketch/distributions_test.cc
+++ b/src/test/cc/any_sketch/distributions_test.cc
@@ -34,7 +34,7 @@ class FakeFingerprinter : public Fingerprinter {
 };
 
 TEST(DistributionsTest, OracleDistribution) {
-  std::unique_ptr<Distribution> distribution =
+  std::unique_ptr<BaseDistribution> distribution =
       GetOracleDistribution("foo", 3, 10);
 
   ASSERT_FALSE(distribution == nullptr);
@@ -53,7 +53,7 @@ TEST(DistributionsTest, OracleDistribution) {
 
 TEST(DistributionsTest, UniformDistribution) {
   FakeFingerprinter fingerprinter;
-  std::unique_ptr<Distribution> distribution =
+  std::unique_ptr<BaseDistribution> distribution =
       GetUniformDistribution(&fingerprinter, 3, 10);
 
   ASSERT_FALSE(distribution == nullptr);
@@ -76,7 +76,7 @@ TEST(DistributionsTest, UniformDistribution) {
 
 TEST(DistributionsTest, ExponentialDistribution) {
   FakeFingerprinter fingerprinter;
-  std::unique_ptr<Distribution> distribution =
+  std::unique_ptr<BaseDistribution> distribution =
       GetExponentialDistribution(&fingerprinter, 2, 10);
 
   ASSERT_FALSE(distribution == nullptr);
@@ -94,7 +94,7 @@ TEST(DistributionsTest, ExponentialDistribution) {
 
 TEST(DistributionsTest, GeometricDistribution) {
   FakeFingerprinter fingerprinter;
-  std::unique_ptr<Distribution> distribution =
+  std::unique_ptr<BaseDistribution> distribution =
       GetGeometricDistribution(&fingerprinter, 10, 74);
 
   ASSERT_FALSE(distribution == nullptr);

--- a/src/test/cc/estimation/estimators_test.cc
+++ b/src/test/cc/estimation/estimators_test.cc
@@ -30,7 +30,7 @@
 
 namespace wfa::estimation {
 namespace {
-using ::wfa::any_sketch::Distribution;
+using ::wfa::any_sketch::BaseDistribution;
 
 MATCHER_P2(EqWithError, value, error, "") {
   // Since value and arg might be of different, possibly unsigned types,
@@ -60,7 +60,7 @@ uint64_t GenerateRandomSketchAndGetSize(double decay_rate,
   absl::flat_hash_set<int64_t> indexes;
 
   const Fingerprinter& fingerprinter = GetSha256Fingerprinter();
-  std::unique_ptr<Distribution> exponential_distribution =
+  std::unique_ptr<BaseDistribution> exponential_distribution =
       wfa::any_sketch::GetExponentialDistribution(&fingerprinter, decay_rate,
                                                   num_of_total_registers);
 


### PR DESCRIPTION
Renamed the base abstract class for `Distribution` to `BaseDistribution`, and renamed the existing concrete `BaseDistribution` to `BaseDistributionImpl` in the C++ source. This is done to avoid a namespace collision with the `Distribution` message in the proto.

Ideally we would have placed the proto in a more scoped package/namespace such as `::wfa::any_sketch::proto::*`, but it's easier to change the C++ symbols since changing the proto could affect the java users

#### Testing 

Built with
```
bazelisk build --config=asan //src/test/...:*
bazelisk build --config=asan //src/main/...:*
```
Test results

```
bazelisk test --config=asan //src/test/...:*

//src/test/cc/any_sketch:aggregators_test                                PASSED in 0.1s
//src/test/cc/any_sketch:any_sketch_test                                 PASSED in 0.2s
//src/test/cc/any_sketch:distributions_test                              PASSED in 0.2s
//src/test/cc/any_sketch/crypto:secret_share_generator_test              PASSED in 0.2s
//src/test/cc/any_sketch/crypto:shuffle_test                             PASSED in 0.2s
//src/test/cc/any_sketch/crypto:sketch_encrypter_adapter_test            PASSED in 4.4s
//src/test/cc/any_sketch/crypto:sketch_encrypter_test                    PASSED in 3.1s
//src/test/cc/estimation:estimators_test                                 PASSED in 0.3s
//src/test/cc/math:distributed_discrete_gaussian_noiser_test             PASSED in 3.8s
//src/test/cc/math:distributed_geometric_noiser_test                     PASSED in 7.0s
//src/test/cc/math:noise_parameters_computation_test                     PASSED in 0.3s
//src/test/cc/math:open_ssl_uniform_random_generator_test                PASSED in 0.2s
```