### PR TITLE
Moved proto messages from package wfa.any_sketch to wfa.any_sketch.proto

### DIFF
--- a/src/main/cc/any_sketch/crypto/key_combiner_main.cc
+++ b/src/main/cc/any_sketch/crypto/key_combiner_main.cc
@@ -25,7 +25,7 @@ ABSL_FLAG(int, curve_id, 0, "The Elliptic curve id.");
 ABSL_FLAG(std::vector<std::string>, element_list, {},
           "The list of ElGamal public key elements to combine.");
 
-using ::wfa::any_sketch::crypto::ElGamalPublicKey;
+using ::wfa::any_sketch::crypto::proto::ElGamalPublicKey;
 
 int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);

--- a/src/main/cc/any_sketch/crypto/secret_share_generator.h
+++ b/src/main/cc/any_sketch/crypto/secret_share_generator.h
@@ -20,8 +20,8 @@
 #include "absl/status/statusor.h"
 #include "wfa/any_sketch/secret_share.pb.h"
 
-using wfa::any_sketch::SecretShare;
-using wfa::any_sketch::SecretShareParameter;
+using wfa::any_sketch::proto::SecretShare;
+using wfa::any_sketch::proto::SecretShareParameter;
 
 namespace wfa::any_sketch::crypto {
 

--- a/src/main/cc/any_sketch/crypto/shuffle.cc
+++ b/src/main/cc/any_sketch/crypto/shuffle.cc
@@ -23,7 +23,7 @@
 namespace wfa::measurement::common::crypto {
 
 absl::Status SecureShuffleWithSeed(std::vector<uint32_t>& data,
-                                   const any_sketch::PrngSeed& seed) {
+                                   const any_sketch::proto::PrngSeed& seed) {
   // Does nothing if the input is empty or has size 1.
   if (data.size() <= 1) {
     return absl::OkStatus();

--- a/src/main/cc/any_sketch/crypto/shuffle.h
+++ b/src/main/cc/any_sketch/crypto/shuffle.h
@@ -30,7 +30,7 @@ namespace wfa::measurement::common::crypto {
 //   Draws a random value j in the range [i; n-1]
 //   Swaps data[i] and data[j]
 absl::Status SecureShuffleWithSeed(std::vector<uint32_t>& data,
-                                   const any_sketch::PrngSeed& seed);
+                                   const any_sketch::proto::PrngSeed& seed);
 
 }  // namespace wfa::measurement::common::crypto
 

--- a/src/main/cc/any_sketch/crypto/sketch_encrypter.cc
+++ b/src/main/cc/any_sketch/crypto/sketch_encrypter.cc
@@ -40,10 +40,10 @@ using ::private_join_and_compute::Context;
 using ::private_join_and_compute::ECGroup;
 using ::private_join_and_compute::ECPoint;
 using ::wfa::any_sketch::DifferentialPrivacyParams;
-using ::wfa::any_sketch::Sketch;
-using ::wfa::any_sketch::SketchConfig;
+using ::wfa::any_sketch::proto::Sketch;
+using ::wfa::any_sketch::proto::SketchConfig;
 using DestroyedRegisterStrategy =
-    ::wfa::any_sketch::crypto::EncryptSketchRequest::DestroyedRegisterStrategy;
+    ::wfa::any_sketch::crypto::proto::EncryptSketchRequest::DestroyedRegisterStrategy;
 using BlindersCiphertext = std::pair<std::string, std::string>;
 // Each Compression of ECPoint has size 33-bytes (32 bytes for x, 1 byte for the
 // sign of y). An ElGamal ciphertext contains two ECPoints, i.e., u and e.
@@ -103,7 +103,7 @@ class SketchEncrypterImpl : public SketchEncrypter {
       DestroyedRegisterStrategy destroyed_register_strategy) override;
 
   absl::Status AppendNoiseRegisters(
-      const EncryptSketchRequest::PublisherNoiseParameter&
+      const proto::EncryptSketchRequest::PublisherNoiseParameter&
           publisher_noise_parameter,
       int value_count, std::string& encrypted_sketch) override;
 
@@ -205,7 +205,7 @@ absl::StatusOr<std::string> SketchEncrypterImpl::Encrypt(
 }
 
 absl::Status SketchEncrypterImpl::AppendNoiseRegisters(
-    const EncryptSketchRequest::PublisherNoiseParameter&
+    const proto::EncryptSketchRequest::PublisherNoiseParameter&
         publisher_noise_parameter,
     int value_count, std::string& encrypted_sketch) {
   // Lock the mutex since most of the crypto computations here are NOT
@@ -292,7 +292,7 @@ absl::Status SketchEncrypterImpl::EncryptDestroyedRegister(
     std::string& encrypted_sketch) {
   ASSIGN_OR_RETURN(std::string index_ec, MapToCurve(reg.index()));
   switch (destroyed_register_strategy) {
-    case EncryptSketchRequest::CONFLICTING_KEYS: {
+    case proto::EncryptSketchRequest::CONFLICTING_KEYS: {
       // Add two registers with the same index for a destroyed register but
       // different values.
       RETURN_IF_ERROR(AppendEncryptedRegisterWithSameValue(
@@ -301,7 +301,7 @@ absl::Status SketchEncrypterImpl::EncryptDestroyedRegister(
           index_ec, reg.values_size(), 2, encrypted_sketch));
       break;
     }
-    case EncryptSketchRequest::FLAGGED_KEY: {
+    case proto::EncryptSketchRequest::FLAGGED_KEY: {
       // ADD one register with all values being the encryption of the
       // KDestroyedRegisterKey constant.
       RETURN_IF_ERROR(AppendFlaggedDestroyedRegister(
@@ -431,8 +431,8 @@ absl::StatusOr<std::unique_ptr<SketchEncrypter>> CreateWithPublicKey(
   return {std::move(result)};
 }
 
-absl::StatusOr<ElGamalPublicKey> CombineElGamalPublicKeys(
-    int curve_id, const std::vector<ElGamalPublicKey>& keys) {
+absl::StatusOr<proto::ElGamalPublicKey> CombineElGamalPublicKeys(
+    int curve_id, const std::vector<proto::ElGamalPublicKey>& keys) {
   if (keys.empty()) {
     return absl::InvalidArgumentError("Keys cannot be empty");
   }
@@ -440,7 +440,7 @@ absl::StatusOr<ElGamalPublicKey> CombineElGamalPublicKeys(
     return keys[0];
   }
 
-  ElGamalPublicKey result;
+  proto::ElGamalPublicKey result;
   result.set_generator(keys[0].generator());
 
   Context ctx;

--- a/src/main/cc/any_sketch/crypto/sketch_encrypter.h
+++ b/src/main/cc/any_sketch/crypto/sketch_encrypter.h
@@ -46,12 +46,12 @@ class SketchEncrypter {
   // Return the word by word ElGamal encryption of the sketch. The result is
   // the concatenation of all ciphertext strings.
   virtual absl::StatusOr<std::string> Encrypt(
-      const wfa::any_sketch::Sketch& sketch,
-      EncryptSketchRequest::DestroyedRegisterStrategy
+      const wfa::any_sketch::proto::Sketch& sketch,
+      proto::EncryptSketchRequest::DestroyedRegisterStrategy
           destroyed_register_strategy) = 0;
 
   virtual absl::Status AppendNoiseRegisters(
-      const EncryptSketchRequest::PublisherNoiseParameter&
+      const proto::EncryptSketchRequest::PublisherNoiseParameter&
           publisher_noise_parameter,
       int value_count, std::string& encrypted_sketch) = 0;
 
@@ -73,8 +73,8 @@ absl::StatusOr<std::unique_ptr<SketchEncrypter>> CreateWithPublicKey(
     const CiphertextString& public_key_bytes);
 
 // Combine a vector of ElGamalPublicKeys whose contain the same generator.
-absl::StatusOr<ElGamalPublicKey> CombineElGamalPublicKeys(
-    int curve_id, const std::vector<ElGamalPublicKey>& keys);
+absl::StatusOr<proto::ElGamalPublicKey> CombineElGamalPublicKeys(
+    int curve_id, const std::vector<proto::ElGamalPublicKey>& keys);
 
 }  // namespace wfa::any_sketch::crypto
 

--- a/src/main/cc/any_sketch/crypto/sketch_encrypter_adapter.cc
+++ b/src/main/cc/any_sketch/crypto/sketch_encrypter_adapter.cc
@@ -28,7 +28,7 @@ namespace wfa::any_sketch::crypto {
 
 absl::StatusOr<std::string> EncryptSketch(
     const std::string& serialized_request) {
-  EncryptSketchRequest request_proto;
+  proto::EncryptSketchRequest request_proto;
   if (!request_proto.ParseFromString(serialized_request)) {
     return absl::InvalidArgumentError(
         "failed to parse the EncryptSketchRequest proto.");
@@ -39,7 +39,7 @@ absl::StatusOr<std::string> EncryptSketch(
                        {.u = request_proto.el_gamal_keys().generator(),
                         .e = request_proto.el_gamal_keys().element()}));
 
-  EncryptSketchResponse response;
+  proto::EncryptSketchResponse response;
   ASSIGN_OR_RETURN(
       *response.mutable_encrypted_sketch(),
       sketch_encrypter->Encrypt(request_proto.sketch(),
@@ -56,13 +56,13 @@ absl::StatusOr<std::string> EncryptSketch(
 
 absl::StatusOr<std::string> CombineElGamalPublicKeys(
     const std::string& serialized_request) {
-  CombineElGamalPublicKeysRequest request_proto;
+  proto::CombineElGamalPublicKeysRequest request_proto;
   if (!request_proto.ParseFromString(serialized_request)) {
     return absl::InvalidArgumentError(
         "failed to parse the CombineElGamalPublicKeysRequest proto.");
   }
-  CombineElGamalPublicKeysResponse response;
-  std::vector<ElGamalPublicKey> keys(request_proto.el_gamal_keys().begin(),
+  proto::CombineElGamalPublicKeysResponse response;
+  std::vector<proto::ElGamalPublicKey> keys(request_proto.el_gamal_keys().begin(),
                                      request_proto.el_gamal_keys().end());
   ASSIGN_OR_RETURN(*response.mutable_el_gamal_keys(),
                    CombineElGamalPublicKeys(request_proto.curve_id(), keys));

--- a/src/main/cc/math/open_ssl_uniform_random_generator.h
+++ b/src/main/cc/math/open_ssl_uniform_random_generator.h
@@ -32,7 +32,7 @@
 
 namespace wfa::math {
 
-using any_sketch::PrngSeed;
+using any_sketch::proto::PrngSeed;
 
 // Key length for EVP_aes_256_ctr.
 // See https://www.openssl.org/docs/man1.1.1/man3/EVP_aes_256_ctr.html

--- a/src/main/proto/wfa/any_sketch/crypto/el_gamal_key.proto
+++ b/src/main/proto/wfa/any_sketch/crypto/el_gamal_key.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package wfa.any_sketch.crypto;
+package wfa.any_sketch.crypto.proto;
 
 option java_package = "org.wfanet.anysketch.crypto";
 option java_multiple_files = true;

--- a/src/main/proto/wfa/any_sketch/crypto/sketch_encryption_methods.proto
+++ b/src/main/proto/wfa/any_sketch/crypto/sketch_encryption_methods.proto
@@ -14,7 +14,7 @@
 
 syntax = "proto3";
 
-package wfa.any_sketch.crypto;
+package wfa.any_sketch.crypto.proto;
 
 import "wfa/any_sketch/crypto/el_gamal_key.proto";
 import "wfa/any_sketch/sketch.proto";
@@ -25,7 +25,7 @@ option java_multiple_files = true;
 // The request to encrypt a sketch.
 message EncryptSketchRequest {
   // The input sketch
-  wfa.any_sketch.Sketch sketch = 1;
+  wfa.any_sketch.proto.Sketch sketch = 1;
   // Public keys of the ElGamal cipher used to encrypt the sketch
   ElGamalPublicKey el_gamal_keys = 2;
   // The elliptical curve to work on.

--- a/src/main/proto/wfa/any_sketch/differential_privacy.proto
+++ b/src/main/proto/wfa/any_sketch/differential_privacy.proto
@@ -16,7 +16,7 @@ syntax = "proto3";
 
 package wfa.any_sketch;
 
-option java_package = "org.wfanet.anysketch";
+option java_package = "org.wfanet.anysketch.proto";
 option java_multiple_files = true;
 
 // For detail of the parameters, refer to "Dwork, C. and Roth, A., 2014. The

--- a/src/main/proto/wfa/any_sketch/secret_share.proto
+++ b/src/main/proto/wfa/any_sketch/secret_share.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package wfa.any_sketch;
+package wfa.any_sketch.proto;
 
 option java_package = "org.wfanet.anysketch";
 option java_multiple_files = true;

--- a/src/main/proto/wfa/any_sketch/sketch.proto
+++ b/src/main/proto/wfa/any_sketch/sketch.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package wfa.any_sketch;
+package wfa.any_sketch.proto;
 
 option java_package = "org.wfanet.anysketch";
 option java_multiple_files = true;

--- a/src/test/cc/any_sketch/crypto/shuffle_test.cc
+++ b/src/test/cc/any_sketch/crypto/shuffle_test.cc
@@ -24,7 +24,7 @@
 namespace wfa::any_sketch::crypto {
 namespace {
 
-using any_sketch::PrngSeed;
+using any_sketch::proto::PrngSeed;
 using measurement::common::crypto::SecureShuffleWithSeed;
 using ::wfa::StatusIs;
 using ::wfa::math::kBytesPerAes256Iv;

--- a/src/test/cc/any_sketch/crypto/sketch_encrypter_adapter_test.cc
+++ b/src/test/cc/any_sketch/crypto/sketch_encrypter_adapter_test.cc
@@ -31,8 +31,8 @@ using ::private_join_and_compute::ECGroup;
 using ::private_join_and_compute::ECPoint;
 using ::private_join_and_compute::InternalError;
 using ::testing::SizeIs;
-using ::wfa::any_sketch::Sketch;
-using ::wfa::any_sketch::SketchConfig;
+using ::wfa::any_sketch::proto::Sketch;
+using ::wfa::any_sketch::proto::SketchConfig;
 
 constexpr int kTestCurveId = NID_X9_62_prime256v1;
 constexpr int kMaxCounterValue = 100;
@@ -81,7 +81,7 @@ TEST(SketchEncrypterJavaAdapterTest, basicBehavior) {
   const int register_size = 1000;
 
   // Build the request
-  wfa::any_sketch::crypto::EncryptSketchRequest request;
+  wfa::any_sketch::crypto::proto::EncryptSketchRequest request;
   request.mutable_el_gamal_keys()->set_generator(public_key_pair.first);
   request.mutable_el_gamal_keys()->set_element(public_key_pair.second);
   request.set_curve_id(kTestCurveId);
@@ -92,7 +92,7 @@ TEST(SketchEncrypterJavaAdapterTest, basicBehavior) {
 
   ASSERT_OK_AND_ASSIGN(std::string encrypted_sketch,
                        EncryptSketch(request.SerializeAsString()));
-  wfa::any_sketch::crypto::EncryptSketchResponse response;
+  wfa::any_sketch::crypto::proto::EncryptSketchResponse response;
   response.ParseFromString(encrypted_sketch);
 
   EXPECT_THAT(response.encrypted_sketch(),
@@ -113,7 +113,7 @@ TEST(SketchEncrypterJavaAdapterTest, noiseShouldBeAddedIfNoiseParameterIsSet) {
   const int bytes_per_register = (index_cnt + unique_cnt + sum_cnt) * 66;
 
   // Build the request
-  wfa::any_sketch::crypto::EncryptSketchRequest request;
+  wfa::any_sketch::crypto::proto::EncryptSketchRequest request;
   request.mutable_noise_parameter()->set_epsilon(1);
   request.mutable_noise_parameter()->set_delta(0.01);
   request.mutable_noise_parameter()->set_publisher_count(3);
@@ -127,7 +127,7 @@ TEST(SketchEncrypterJavaAdapterTest, noiseShouldBeAddedIfNoiseParameterIsSet) {
 
   ASSERT_OK_AND_ASSIGN(std::string encrypted_sketch,
                        EncryptSketch(request.SerializeAsString()));
-  wfa::any_sketch::crypto::EncryptSketchResponse response;
+  wfa::any_sketch::crypto::proto::EncryptSketchResponse response;
   response.ParseFromString(encrypted_sketch);
 
   EXPECT_GT(response.encrypted_sketch().size(),

--- a/src/test/cc/any_sketch/crypto/sketch_encrypter_test.cc
+++ b/src/test/cc/any_sketch/crypto/sketch_encrypter_test.cc
@@ -35,9 +35,9 @@ using ::private_join_and_compute::ECGroup;
 using ::private_join_and_compute::ECPoint;
 using ::testing::Not;
 using ::testing::SizeIs;
-using ::wfa::any_sketch::Sketch;
-using ::wfa::any_sketch::SketchConfig;
-using ::wfa::any_sketch::crypto::ElGamalPublicKey;
+using ::wfa::any_sketch::proto::Sketch;
+using ::wfa::any_sketch::proto::SketchConfig;
+using ::wfa::any_sketch::crypto::proto::ElGamalPublicKey;
 
 constexpr int kTestCurveId = NID_X9_62_prime256v1;
 constexpr int kMaxCounterValue = 100;
@@ -178,13 +178,13 @@ class SketchEncrypterTest : public ::testing::Test {
   }
 
   absl::StatusOr<std::string> EncryptWithConflictingKeys(const Sketch& sketch) {
-    return sketch_encrypter_->Encrypt(sketch,
-                                      EncryptSketchRequest::CONFLICTING_KEYS);
+    return sketch_encrypter_->Encrypt(
+        sketch, proto::EncryptSketchRequest::CONFLICTING_KEYS);
   }
 
   absl::StatusOr<std::string> EncryptWithFlaggedKey(const Sketch& sketch) {
-    return sketch_encrypter_->Encrypt(sketch,
-                                      EncryptSketchRequest::FLAGGED_KEY);
+    return sketch_encrypter_->Encrypt(
+        sketch, proto::EncryptSketchRequest::FLAGGED_KEY);
   }
 
   // The ElGamal Cipher whose public key is used to create the SketchEncrypter.
@@ -425,7 +425,7 @@ TEST_F(SketchEncrypterTest, NoisesShouldHaveTheSameIndex) {
   int values_per_register = 5;
   int ciphertexts_per_register = (values_per_register + 1) * 2;
 
-  EncryptSketchRequest::PublisherNoiseParameter noise_parameter;
+  proto::EncryptSketchRequest::PublisherNoiseParameter noise_parameter;
   noise_parameter.set_epsilon(1);
   noise_parameter.set_delta(0.1);
   noise_parameter.set_publisher_count(3);


### PR DESCRIPTION
Since we specify a `java_package` in the [proto message](https://github.com/world-federation-of-advertisers/any-sketch/blob/89d7e73fcaedef868f1ddbea82a291ca37851491/src/main/proto/wfa/any_sketch/sketch.proto#L23), this suggests we may be able to change the package scoping while keeping everyone's java codebases intact, assuming the overrides work the way I think they do as described in https://protobuf.dev/programming-guides/proto3/#packages

#### Testing 

Built with

bazelisk build --config=asan //src/test/...:*
bazelisk build --config=asan //src/main/...:*

Tested with

bazelisk test --config=asan //src/test/...:*

//src/test/cc/any_sketch:aggregators_test                                PASSED in 0.1s
//src/test/cc/any_sketch:any_sketch_test                                 PASSED in 0.1s
//src/test/cc/any_sketch:distributions_test                              PASSED in 0.2s
//src/test/cc/any_sketch/crypto:secret_share_generator_test              PASSED in 0.3s
//src/test/cc/any_sketch/crypto:shuffle_test                             PASSED in 0.3s
//src/test/cc/any_sketch/crypto:sketch_encrypter_adapter_test            PASSED in 4.3s
//src/test/cc/any_sketch/crypto:sketch_encrypter_test                    PASSED in 3.0s
//src/test/cc/estimation:estimators_test                                 PASSED in 0.3s
//src/test/cc/math:distributed_discrete_gaussian_noiser_test             PASSED in 3.7s
//src/test/cc/math:distributed_geometric_noiser_test                     PASSED in 7.0s
//src/test/cc/math:noise_parameters_computation_test                     PASSED in 0.3s
//src/test/cc/math:open_ssl_uniform_random_generator_test                PASSED in 0.2s

Executed 12 out of 12 tests: 12 tests pass.